### PR TITLE
require jinja2 >=3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 26dcd9218d5544cc15144f60bb5b634f2276e476c89f481b3f619c4f9def1588
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - python >=3.5
   run:
     - cryptography
-    - jinja2
+    - jinja2 >=3.0
     - packaging
     - python >=3.5
     - pyyaml


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Ensured the license file is being packaged.

This requires `jinja2 >=3.0` rather than leaving the version unspecified.  Fixes #19.